### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "cd kahoot-tools npm install # or use yarn # Edit config.json npm run build npm run host"

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ idiidk – [@idiidka](https://twitter.com/idiidka)
 Distributed under the MIT license. See ``LICENSE`` for more information.
 
 [https://github.com/idiidk](https://github.com/idiidk/)
+[![Run on Repl.it](https://repl.it/badge/github/davidzhao-lab/kahootbotunblocked)](https://repl.it/github/davidzhao-lab/kahootbotunblocked)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@David247/kahootbotunblocked).